### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Augmentor
 click
 matplotlib
-numpy
+numpy==1.16.4
+keras
 pandas
 pillow
 sklearn


### PR DESCRIPTION
The release of TF2.0 and Numpy 1.17 causes a number of "future warning" error messages. Specifically setting things to include Keras and Numpy 1.16.4 removes these errors without needing to update the entire code base.
