### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sklearn
 tensorflow
 jinja2
 progressbar2
+scipy


### PR DESCRIPTION
Most distros return the error `ModuleNotFoundError: No module named 'sklearn'` because of missing dependency `scipy`
